### PR TITLE
Add warning

### DIFF
--- a/check_process
+++ b/check_process
@@ -1,5 +1,6 @@
 ;; Test complet
 	; Manifest
+		warning="Understood"
 		domain="domain.tld"	(DOMAIN)
 		admin="john"	(USER)
 		language="fr"

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,15 @@
     "arguments": {
         "install" : [
             {
+                "name": "warning",
+                "type": "string",
+                "ask": {
+                    "text": "\nMobilizon is in early development, a lot of features are not implemented.\n\nFor advanced testing use only.\n\n"
+                },
+                "choices": ["Understood"],
+                "default": "Understood"
+            },
+            {
                 "name": "domain",
                 "type": "domain",
                 "ask": {


### PR DESCRIPTION
## Problem
- *Mobilizon is in early development and a lot of features are not already implemented*

## Solution
- *Add warning during install*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
- [ ] **Code review**
- [ ] **Approval (LGTM)**  
*Code review and approval have to be from a member of @YunoHost/apps group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/mobilizon_ynh_PR11%20(yalh76)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/mobilizon_ynh_PR11%20(yalh76)/)  
![Capture](https://user-images.githubusercontent.com/30271971/56463378-5e214a00-63d3-11e9-811d-92e1fa7f0a31.PNG)

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
