### PR TITLE
Need quotes here (same issue as Mastodon)

### DIFF
--- a/scripts/ynh_add_extra_apt_repos__3
+++ b/scripts/ynh_add_extra_apt_repos__3
@@ -128,7 +128,7 @@ ynh_install_extra_repo () {
 	local component="${repo##$uri $suite }"
 
 	# Add the repository into sources.list.d
-	ynh_add_repo --uri="$uri" --suite="$suite" --component="$component" --name="$name" $append
+	ynh_add_repo --uri="$uri" --suite="$suite" --component="$component" --name="$name" "$append"
 
 	# Pin the new repo with the default priority, so it won't be used for upgrades.
 	# Build $pin from the uri without http and any sub path
@@ -139,7 +139,7 @@ ynh_install_extra_repo () {
 	then
 		priority="--priority=$priority"
 	fi
-	ynh_pin_repo --package="*" --pin="origin \"$pin\"" $priority --name="$name" $append
+	ynh_pin_repo --package="*" --pin="origin \"$pin\"" $priority --name="$name" "$append"
 
 	# Get the public key for the repo
 	if [ -n "$key" ]


### PR DESCRIPTION
## Problem

Same issue as Mastodon and Codimd

## Solution

Need quotes here because getopts aint happy about empty args

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/mobilizon_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/mobilizon_ynh%20PR-NUM-%20(USERNAME)/)  
