### PR TITLE
Yunohost 11.1 - Fix deprecated options for yunohost user create helper with

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A decentralized and federated platform to organize events
 
 
 
-**Shipped version:** 2.1.0.1~ynh5
+**Shipped version:** 2.1.0.1~ynh6
 
 
 **Demo:** https://demo.mobilizon.org

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A decentralized and federated platform to organize events
 
 
 
-**Shipped version:** 2.1.0.1~ynh4
+**Shipped version:** 2.1.0.1~ynh5
 
 
 **Demo:** https://demo.mobilizon.org

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,7 +23,7 @@ A decentralized and federated platform to organize events
 
 
 
-**Version incluse :** 2.1.0.1~ynh5
+**Version incluse :** 2.1.0.1~ynh6
 
 
 **Démo :** https://demo.mobilizon.org

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,7 +23,7 @@ A decentralized and federated platform to organize events
 
 
 
-**Version incluse :** 2.1.0.1~ynh4
+**Version incluse :** 2.1.0.1~ynh5
 
 
 **Démo :** https://demo.mobilizon.org

--- a/conf/mail.exs
+++ b/conf/mail.exs
@@ -1,7 +1,9 @@
 
 config :mobilizon, Mobilizon.Web.Email.Mailer,
-  adapter: Swoosh.Adapters.SMTP,
-  relay: "127.0.0.1",
+  #adapter: Swoosh.Adapters.SMTP,
+  #relay: "127.0.0.1",
+  adapter: Bamboo.SMTPAdapter,
+  server: "127.0.0.1",
   #hostname: "127.0.0.1",
   # usually 25, 465 or 587
   port: 25,

--- a/conf/mail.exs
+++ b/conf/mail.exs
@@ -2,7 +2,7 @@
 config :mobilizon, Mobilizon.Web.Email.Mailer,
   adapter: Swoosh.Adapters.SMTP,
   relay: "127.0.0.1",
-  #hostname: "127.0.0.1",
+  hostname: "127.0.0.1",
   # usually 25, 465 or 587
   port: 25,
   username: "__YNH_USER__",

--- a/conf/mail.exs
+++ b/conf/mail.exs
@@ -2,7 +2,7 @@
 config :mobilizon, Mobilizon.Web.Email.Mailer,
   adapter: Swoosh.Adapters.SMTP,
   relay: "127.0.0.1",
-  hostname: "127.0.0.1",
+  #hostname: "127.0.0.1",
   # usually 25, 465 or 587
   port: 25,
   username: "__YNH_USER__",
@@ -15,4 +15,3 @@ config :mobilizon, Mobilizon.Web.Email.Mailer,
   no_mx_lookups: false,
   # can be `:always`. If your smtp relay requires authentication set it to `:always`.
   auth: :always
-

--- a/conf/mail.exs
+++ b/conf/mail.exs
@@ -1,9 +1,9 @@
 
 config :mobilizon, Mobilizon.Web.Email.Mailer,
-  #adapter: Swoosh.Adapters.SMTP,
-  #relay: "127.0.0.1",
-  adapter: Bamboo.SMTPAdapter,
-  server: "127.0.0.1",
+  adapter: Swoosh.Adapters.SMTP,
+  relay: "127.0.0.1",
+  #adapter: Bamboo.SMTPAdapter,
+  #server: "127.0.0.1",
   #hostname: "127.0.0.1",
   # usually 25, 465 or 587
   port: 25,

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A decentralized and federated platform to organize events",
         "fr": "Une plateforme décentralisée et fédérée pour organiser des événements"
     },
-    "version": "2.1.0.1~ynh5",
+    "version": "2.1.0.1~ynh6",
     "url": "https://joinmobilizon.org/",
     "upstream": {
         "license": "AGPL-3.0-or-later",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A decentralized and federated platform to organize events",
         "fr": "Une plateforme décentralisée et fédérée pour organiser des événements"
     },
-    "version": "2.1.0.1~ynh6",
+    "version": "2.1.0.1~ynh7",
     "url": "https://joinmobilizon.org/",
     "upstream": {
         "license": "AGPL-3.0-or-later",

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
         "name": "yalh76"
     },
     "requirements": {
-        "yunohost": ">= 11.0"
+        "yunohost": ">= 11.1"
     },
     "multi_instance": false,
     "services": [

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
         "name": "yalh76"
     },
     "requirements": {
-        "yunohost": ">= 4.3.0"
+        "yunohost": ">= 11.1"
     },
     "multi_instance": false,
     "services": [

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A decentralized and federated platform to organize events",
         "fr": "Une plateforme décentralisée et fédérée pour organiser des événements"
     },
-    "version": "2.1.0.1~ynh7",
+    "version": "2.1.0.1~ynh4",
     "url": "https://joinmobilizon.org/",
     "upstream": {
         "license": "AGPL-3.0-or-later",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A decentralized and federated platform to organize events",
         "fr": "Une plateforme décentralisée et fédérée pour organiser des événements"
     },
-    "version": "2.1.0.1~ynh4",
+    "version": "2.1.0.1~ynh5",
     "url": "https://joinmobilizon.org/",
     "upstream": {
         "license": "AGPL-3.0-or-later",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A decentralized and federated platform to organize events",
         "fr": "Une plateforme décentralisée et fédérée pour organiser des événements"
     },
-    "version": "2.1.0.1~ynh4",
+    "version": "2.1.0.1~ynh5",
     "url": "https://joinmobilizon.org/",
     "upstream": {
         "license": "AGPL-3.0-or-later",
@@ -20,7 +20,7 @@
         "name": "yalh76"
     },
     "requirements": {
-        "yunohost": ">= 11.1"
+        "yunohost": ">= 11.0"
     },
     "multi_instance": false,
     "services": [

--- a/scripts/install
+++ b/scripts/install
@@ -86,7 +86,7 @@ ynh_script_progression --message="Configuring system user..."
 # Create a system user
 ynh_system_user_create --username=$app --home_dir="$final_path"
 
-yunohost user create ${app}_notifs F Mobilizon Notifications --domain "$domain" --password "$ynh_user_password" -q 0
+yunohost user create ${app}_notifs -F Mobilizon Notifications --domain "$domain" --password "$ynh_user_password" -q 0
 yunohost user update ${app}_notifs --add-mailalias $app@$domain --add-mailforward $admin_email
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -86,7 +86,7 @@ ynh_script_progression --message="Configuring system user..."
 # Create a system user
 ynh_system_user_create --username=$app --home_dir="$final_path"
 
-yunohost user create ${app}_notifs --firstname "Mobilizon" --lastname "Notifications" --domain "$domain" --password "$ynh_user_password" -q 0
+yunohost user create ${app}_notifs F Mobilizon Notifications --domain "$domain" --password "$ynh_user_password" -q 0
 yunohost user update ${app}_notifs --add-mailalias $app@$domain --add-mailforward $admin_email
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -86,7 +86,7 @@ ynh_script_progression --message="Configuring system user..."
 # Create a system user
 ynh_system_user_create --username=$app --home_dir="$final_path"
 
-yunohost user create ${app}_notifs -F Mobilizon Notifications --domain "$domain" --password "$ynh_user_password" -q 0
+yunohost user create ${app}_notifs -F "Mobilizon Notifications" --domain "$domain" --password "$ynh_user_password" -q 0
 yunohost user update ${app}_notifs --add-mailalias $app@$domain --add-mailforward $admin_email
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -55,7 +55,7 @@ ynh_script_progression --message="Recreating the dedicated system user..."
 # Create the dedicated user (if not existing)
 ynh_system_user_create --username=$app --home_dir=$final_path
 
-yunohost user create ${app}_notifs --firstname "Mobilizon" --lastname "Notifications" --domain "$domain" --password "$ynh_user_password" -q 0
+yunohost user create ${app}_notifs -F Mobilizon Notifications --domain "$domain" --password "$ynh_user_password" -q 0
 yunohost user update ${app}_notifs --add-mailalias $app@$domain --add-mailforward $admin_email
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -55,7 +55,7 @@ ynh_script_progression --message="Recreating the dedicated system user..."
 # Create the dedicated user (if not existing)
 ynh_system_user_create --username=$app --home_dir=$final_path
 
-yunohost user create ${app}_notifs -F Mobilizon Notifications --domain "$domain" --password "$ynh_user_password" -q 0
+yunohost user create ${app}_notifs -F "Mobilizon Notifications" --domain "$domain" --password "$ynh_user_password" -q 0
 yunohost user update ${app}_notifs --add-mailalias $app@$domain --add-mailforward $admin_email
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -98,7 +98,7 @@ if ynh_version_gt "1.0.0~ynh1" "${previous_version}" ; then
 	ynh_user_password=$(ynh_string_random --length=30)
 	ynh_app_setting_set --app=$app --key=ynh_user_password --value=$ynh_user_password
 
-	yunohost user create ${app}_notifs --firstname "Mobilizon" --lastname "Notifications" --domain $domain --password "$ynh_user_password" -q 0
+	yunohost user create ${app}_notifs -F Mobilizon Notifications --domain $domain --password "$ynh_user_password" -q 0
 	yunohost user update ${app}_notifs --add-mailalias $app@$domain --add-mailforward $admin_email
 
 	# Manage previous .env file

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -245,11 +245,11 @@ popd
 #=================================================
 #ynh_script_progression --message="Updating a configuration file..."
 
-#config="/etc/$app/config.exs"
+config="/etc/$app/config.exs"
 
 ynh_backup_if_checksum_is_different --file="$config"
-#ynh_replace_string --match_string="adapter: Bamboo.SMTPAdapter," --replace_string="adapter: Swoosh.Adapters.SMTP," --target_file="$config"
-#ynh_replace_string --match_string="server: \"127.0.0.1\"," --replace_string="relay: \"127.0.0.1\"," --target_file="$config"
+ynh_replace_string --match_string="adapter: Swoosh.Adapters.SMTP," --replace_string="adapter: Bamboo.SMTPAdapter," --target_file="$config"
+ynh_replace_string --match_string="relay: \"127.0.0.1\"," --replace_string="server: \"127.0.0.1\"," --target_file="$config"
 ynh_store_file_checksum --file="$config"
 
 chmod 400 "$config"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -248,8 +248,8 @@ ynh_script_progression --message="Updating a configuration file..."
 config="/etc/$app/config.exs"
 
 ynh_backup_if_checksum_is_different --file="$config"
-# ynh_replace_string --match_string="adapter: Bamboo.SMTPAdapter," --replace_string="adapter: Swoosh.Adapters.SMTP," --target_file="$config"
-# ynh_replace_string --match_string="server: \"127.0.0.1\"," --replace_string="relay: \"127.0.0.1\"," --target_file="$config"
+ynh_replace_string --match_string="adapter: Bamboo.SMTPAdapter," --replace_string="adapter: Swoosh.Adapters.SMTP," --target_file="$config"
+ynh_replace_string --match_string="server: \"127.0.0.1\"," --replace_string="relay: \"127.0.0.1\"," --target_file="$config"
 ynh_store_file_checksum --file="$config"
 
 chmod 400 "$config"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -98,7 +98,7 @@ if ynh_version_gt "1.0.0~ynh1" "${previous_version}" ; then
 	ynh_user_password=$(ynh_string_random --length=30)
 	ynh_app_setting_set --app=$app --key=ynh_user_password --value=$ynh_user_password
 
-	yunohost user create ${app}_notifs -F Mobilizon Notifications --domain $domain --password "$ynh_user_password" -q 0
+	yunohost user create ${app}_notifs -F "Mobilizon Notifications" --domain $domain --password "$ynh_user_password" -q 0
 	yunohost user update ${app}_notifs --add-mailalias $app@$domain --add-mailforward $admin_email
 
 	# Manage previous .env file

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -248,8 +248,8 @@ ynh_script_progression --message="Updating a configuration file..."
 config="/etc/$app/config.exs"
 
 ynh_backup_if_checksum_is_different --file="$config"
-#ynh_replace_string --match_string="adapter: Bamboo.SMTPAdapter," --replace_string="adapter: Swoosh.Adapters.SMTP," --target_file="$config"
-#ynh_replace_string --match_string="server: \"127.0.0.1\"," --replace_string="relay: \"127.0.0.1\"," --target_file="$config"
+# ynh_replace_string --match_string="adapter: Bamboo.SMTPAdapter," --replace_string="adapter: Swoosh.Adapters.SMTP," --target_file="$config"
+# ynh_replace_string --match_string="server: \"127.0.0.1\"," --replace_string="relay: \"127.0.0.1\"," --target_file="$config"
 ynh_store_file_checksum --file="$config"
 
 chmod 400 "$config"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -248,8 +248,8 @@ ynh_script_progression --message="Updating a configuration file..."
 config="/etc/$app/config.exs"
 
 ynh_backup_if_checksum_is_different --file="$config"
-ynh_replace_string --match_string="adapter: Bamboo.SMTPAdapter," --replace_string="adapter: Swoosh.Adapters.SMTP," --target_file="$config"
-ynh_replace_string --match_string="server: \"127.0.0.1\"," --replace_string="relay: \"127.0.0.1\"," --target_file="$config"
+#ynh_replace_string --match_string="adapter: Bamboo.SMTPAdapter," --replace_string="adapter: Swoosh.Adapters.SMTP," --target_file="$config"
+#ynh_replace_string --match_string="server: \"127.0.0.1\"," --replace_string="relay: \"127.0.0.1\"," --target_file="$config"
 ynh_store_file_checksum --file="$config"
 
 chmod 400 "$config"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -243,13 +243,13 @@ popd
 #=================================================
 # UPDATE A CONFIG FILE
 #=================================================
-ynh_script_progression --message="Updating a configuration file..."
+#ynh_script_progression --message="Updating a configuration file..."
 
-config="/etc/$app/config.exs"
+#config="/etc/$app/config.exs"
 
 ynh_backup_if_checksum_is_different --file="$config"
-ynh_replace_string --match_string="adapter: Bamboo.SMTPAdapter," --replace_string="adapter: Swoosh.Adapters.SMTP," --target_file="$config"
-ynh_replace_string --match_string="server: \"127.0.0.1\"," --replace_string="relay: \"127.0.0.1\"," --target_file="$config"
+#ynh_replace_string --match_string="adapter: Bamboo.SMTPAdapter," --replace_string="adapter: Swoosh.Adapters.SMTP," --target_file="$config"
+#ynh_replace_string --match_string="server: \"127.0.0.1\"," --replace_string="relay: \"127.0.0.1\"," --target_file="$config"
 ynh_store_file_checksum --file="$config"
 
 chmod 400 "$config"


### PR DESCRIPTION
## Problem

- *Since upgrade with yunohost 11.1 are deprecated options `--first-name` and/or  `--last-name`*

## Solution

- *replace by option fullname `-F`*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
