### PR TITLE
Fix install fail - add missing dependencies

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="postgresql postgresql-client postgresql-contrib postgis postgresql-postgis-scripts argon2 imagemagick webp gifsicle jpegoptim optipng pngquant file"
+pkg_dependencies="postgresql postgresql-client postgresql-contrib postgis postgresql-postgis-scripts postgresql-13-postgis-3 argon2 imagemagick webp gifsicle jpegoptim optipng pngquant file"
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
Adding 

## Problem

- [*Installation fails due to missing dependency*](https://github.com/YunoHost-Apps/mobilizon_ynh/issues/35)

## Solution

- Adding missing dependency: `postgresql-13-postgis-3`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
