### PR TITLE
change smtp module adapter

### DIFF
--- a/conf/mail.exs
+++ b/conf/mail.exs
@@ -1,9 +1,7 @@
 
 config :mobilizon, Mobilizon.Web.Email.Mailer,
-  #adapter: Swoosh.Adapters.SMTP,
-  #relay: "127.0.0.1",
-  adapter: Bamboo.SMTPAdapter,
-  server: "127.0.0.1",
+  adapter: Swoosh.Adapters.SMTP,
+  relay: "127.0.0.1",
   #hostname: "127.0.0.1",
   # usually 25, 465 or 587
   port: 25,

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
         "name": "yalh76"
     },
     "requirements": {
-        "yunohost": ">= 4.3.0"
+        "yunohost": ">= 11.0.0"
     },
     "multi_instance": false,
     "services": [


### PR DESCRIPTION
## Problem

- *since the v2.0.2 the module changed for the smtp adapter*

## Solution

- *explained here https://framagit.org/framasoft/mobilizon/-/blob/main/UPGRADE.md#mailer-library-change*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
