### PR TITLE
Update mail.exs

### DIFF
--- a/conf/mail.exs
+++ b/conf/mail.exs
@@ -4,12 +4,19 @@ config :mobilizon, Mobilizon.Web.Email.Mailer,
   relay: "127.0.0.1",
   #hostname: "127.0.0.1",
   # usually 25, 465 or 587
-  port: 25,
+  port: 587,
   username: "__YNH_USER__",
   password: "__YNH_USER_PASSWORD__",
   # can be `:always` or `:never`
-  tls: :if_available,
-  allowed_tls_versions: [:"tlsv1.2"],
+  tls: :always,
+  tls_options: [
+    versions: [:"tlsv1.2",:"tlsv1.3"],
+    verify: :verify_peer,
+    cacerts: :public_key.cacerts_get(),
+    server_name_indication: '__DOMAIN__',
+    depth: 99
+  ],
+  ssl: false,
   retries: 1,
   # can be `true`
   no_mx_lookups: false,


### PR DESCRIPTION
New conf to work with smtp starttls in yunohost

## Problem

Email not working in yunohost, because it uses starttls

## Solution

New email configuration that works in my case

## PR Status

- Need to test, I have doubt about the variable __DOMAIN__
I'm sorry, but I'm new to yunohost and IO don't know ho to test the script in a testing environment.

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
