### PR TITLE
Update upstream to Kaihuri and use LDAP for admin user

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -16,7 +16,7 @@ license = "AGPL-3.0-or-later"
 website = "https://joinmobilizon.org/"
 demo = "https://demo.mobilizon.org"
 userdoc = "https://docs.joinmobilizon.org"
-code = "https://framagit.org/framasoft/mobilizon/"
+code = "https://framagit.org/kaihuri/mobilizon/"
 fund = "https://soutenir.framasoft.org/"
 
 [integration]

--- a/scripts/install
+++ b/scripts/install
@@ -102,9 +102,9 @@ chmod -R u+rwX,g+rwX "/var/lib/${app}"
 
 ynh_systemctl --service="$app" --action="start" --log_path=systemd --wait_until="Access Mobilizon.Web.Endpoint at"
 
-# We generate a dummy password... this will actually *not* be used because the admin is supposed to connect via the ldap
+# Admin is created with LDAP provider since authentication goes through YunoHost's LDAP
 ynh_exec_as_app MOBILIZON_CONFIG_PATH="$install_dir/config.exs" "$install_dir/live/bin/mobilizon_ctl" \
-    users.new "$admin_email" --admin --password "$(ynh_string_random --length=30)"
+    users.new "$admin_email" --admin --provider ldap
 
 ynh_systemctl --service="$app" --action="stop" --log_path=systemd
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -124,6 +124,10 @@ ynh_script_progression "Starting $app's systemd service..."
 
 ynh_systemctl --service="$app" --action="start" --log_path=systemd --wait_until="Access Mobilizon.Web.Endpoint at"
 
+# Fix admin user provider for LDAP authentication (previously created without --provider ldap)
+ynh_exec_as_app MOBILIZON_CONFIG_PATH="$install_dir/config.exs" "$install_dir/live/bin/mobilizon_ctl" \
+    users.modify "$admin_email" --provider ldap || true
+
 #=================================================
 # END OF SCRIPT
 #=================================================


### PR DESCRIPTION
## Problem

1. Resolve lack of admin user access on initial install, allow YunoHost LDAP (https://github.com/YunoHost-Apps/mobilizon_ynh/issues/234)
2. We are pointing to the outdated upstream, Kaihuri has taken over maintenance of Mobilizon

## Solution

Updates both the upgrade and install to use LDAP

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
